### PR TITLE
docs: Update edx.rtd.io links to docs.openedx.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supported formats:
 
 - [Markdown](https://daringfireball.net/projects/markdown/): with [Pandoc-flavoured](https://garrettgman.github.io/rmarkdown/authoring_pandoc_markdown.html) header attributes.
 - HTML 5
-- Open Learning XML ([OLX](https://edx.readthedocs.io/projects/edx-open-learning-xml/)) from [Open edX](https://openedx.org).
+- Open Learning XML ([OLX](https://docs.openedx.org/en/latest/educators/navigation/olx.html)) from [Open edX](https://openedx.org).
 
 Check out the [course.md](https://github.com/overhangio/mu/blob/main/examples/course.md) file to see what an actual course in Markdown format looks like.
 

--- a/mu/formats/olx/reader.py
+++ b/mu/formats/olx/reader.py
@@ -63,8 +63,8 @@ class InlineReader(BaseReader):
 
     def on_problem(self, unit_xml: BeautifulSoup) -> t.Iterable[units.Unit]:
         """
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/problem-xml/checkbox.html
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/problem-xml/text_input.html
+        https://docs.openedx.org/en/latest/educators/references/course_development/exercise_tools/multi_select_xml.html
+        https://docs.openedx.org/en/latest/educators/references/course_development/exercise_tools/text_input_xml.html
         """
         # Parse question
         question_xml = unit_xml.find("label")
@@ -97,7 +97,7 @@ class InlineReader(BaseReader):
 
     def on_html(self, unit_xml: BeautifulSoup) -> t.Iterable[units.Unit]:
         """
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/components/html-components.html
+        https://docs.openedx.org/en/latest/educators/olx/components/html-components.html
         """
         contents = "\n".join([str(c) for c in unit_xml.contents])
         yield units.RawHtml(
@@ -106,7 +106,7 @@ class InlineReader(BaseReader):
 
     def on_video(self, unit_xml: BeautifulSoup) -> t.Iterable[units.Unit]:
         """
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/components/video-components.html
+        https://docs.openedx.org/en/latest/educators/olx/components/video-components.html
         """
         sources: t.List[str] = []
         if youtube_id := unit_xml.attrs.get("youtube_id_1_0"):

--- a/mu/formats/olx/writer.py
+++ b/mu/formats/olx/writer.py
@@ -55,10 +55,10 @@ class Writer(BaseWriter):
 
     def on_multiplechoicequestion(self, unit: units.MultipleChoiceQuestion) -> None:
         """
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/problem-xml/checkbox.html
+        https://docs.openedx.org/en/latest/educators/references/course_development/exercise_tools/multi_select_xml.html
 
         Note that we generate checkbox problems by default, and not multiple choice problem, which support only a single answer:
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/problem-xml/multiple_choice.html#multiple-choice-problem-olx-reference
+        https://docs.openedx.org/en/latest/educators/references/course_development/exercise_tools/single_select_xml.html
         """
         problem_xml = self.process_unit(unit, "problem")
         response_xml = Tag(name="choiceresponse")
@@ -79,7 +79,7 @@ class Writer(BaseWriter):
 
     def on_freetextquestion(self, unit: units.MultipleChoiceQuestion) -> None:
         """
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/problem-xml/text_input.html
+        https://docs.openedx.org/en/latest/educators/references/course_development/exercise_tools/text_input_xml.html
         """
         problem_xml = self.process_unit(unit, "problem")
         response_xml = Tag(name="stringresponse")
@@ -98,7 +98,7 @@ class Writer(BaseWriter):
 
     def on_rawhtml(self, unit: units.RawHtml) -> None:
         """
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/components/html-components.html
+        https://docs.openedx.org/en/latest/educators/olx/components/html-components.html
 
         Note that the spec is incorrect. We should use "filename" and not "file_name".
         """
@@ -120,7 +120,7 @@ class Writer(BaseWriter):
 
     def on_video(self, unit: units.Video) -> None:
         """
-        https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/components/video-components.html
+        https://docs.openedx.org/en/latest/educators/olx/components/video-components.html
         """
         video_xml = self.process_unit(unit, "video")
         # We need to define an empty youtube url; otherwise the default video with Anant is picked up.


### PR DESCRIPTION
With the move to docs.openedx.org, update outdated reference links.

Ref: https://github.com/openedx/docs.openedx.org/issues/988
